### PR TITLE
Add setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+hgvs
+pyfaidx
+pyensemblrest
+pandas

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+from setuptools import setup
+def get_contents(*args):
+    """Get the contents of a file relative to the source distribution directory."""
+    with codecs.open(get_absolute_path(*args), 'r', 'UTF-8') as handle:
+        return handle.read()
+
+def get_requirements(*args):
+    """Get requirements from pip requirement files."""
+    requirements = set()
+    with open(get_absolute_path(*args)) as handle:
+        for line in handle:
+            # Strip comments.
+            line = re.sub(r'^#.*|\s#.*', '', line)
+            # Ignore empty lines
+            if line and not line.isspace():
+                requirements.add(re.sub(r'\s+', '', line))
+    return sorted(requirements)
+
+setup(
+    name='VIS',
+    version='0.1.0',
+    install_requires=get_requirements('requirements.txt'),
+    url='https://github.com/KyranWissink/VIS',
+    license='',
+    author='Kyran Wissink',
+    author_email='',
+    description='VIS: HGVS variant interpretation using SPLICEAI',
+    classifiers=[
+        "Programming Language :: Python :: 3.7",
+        "Operating System :: OS Independent",
+    ],
+    long_description=get_contents('README.md'),
+    python_requires=">=3.7",
+)


### PR DESCRIPTION
Although completely optional / not required you could add and expand a setup.py and a requirements.txt for easy installation. You could also consider to add testing using for example travis and codecov.

This is more as a learning opportunity than a actual need for this projects though.

this setup.py was created using the gsport and coloredlogs github python projects as an example

edited in pycharm community edition